### PR TITLE
[GH Action] Add the spark-ios root path on xcresult export

### DIFF
--- a/.github/workflows/buildDemoApp.yml
+++ b/.github/workflows/buildDemoApp.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ failure() }}
         with:
           name: ${{ env.app_name }}-${{ github.run_number }}.xcresult
-          path: ${{ env.app_name }}.xcresult
+          path: spark-ios/${{ env.app_name }}.xcresult
           retention-days: 15
 
       - name: Upload demo app file


### PR DESCRIPTION
The current path of the xcresult is wrong. 
This PR should fix the issue.