### PR TITLE
[Accessibility] Add common management for subview in SwiftUI

### DIFF
--- a/Sources/Core/Accessibility/Model/Accessibility.swift
+++ b/Sources/Core/Accessibility/Model/Accessibility.swift
@@ -1,0 +1,74 @@
+//
+//  Accessibility.swift
+//  SparkCommon
+//
+//  Created by robin.lemaire on 16/12/2024.
+//  Copyright © 2023 Adevinta. All rights reserved.
+//
+
+import SwiftUI
+
+// TODO: voir pour faire du cas par cas coté Component (ne laisser ouvert que le label coté Formfield + Hint sur le title par exemple)... Et utiliser ensuite ce modèle en interne afin de set rapidement toutes les valeurs (sur le FormField: le label + hint pour le title)
+
+/// Struct using to manage the accessibility properties on SwiftUI.
+@_spi(SI_SPI) public struct Accessibility {
+
+    // MARK: - Properties
+
+    public var label: String?
+    public var value: String?
+    public var inputLabels: [String]?
+    public var hint: String?
+    public var hidden: Bool?
+    public var action: Action?
+
+    // MARK: - Initialization
+
+    /// Init the accessibility struct.
+    /// - Parameters:
+    ///   - label: the accessibility label. *Optional*. Nil by default. If the value is nil, the accessibilityLabel will not be setted.
+    ///   - value: the accessibility value. *Optional*. Nil by default. If the value is nil, the accessibilityValue will not be setted.
+    ///   - inputLabels: the accessibility input labels. *Optional*. Nil by default. If the value is nil, the accessibilityInputLabels will not be setted.
+    ///   - hint: the accessibility hint. *Optional*. Nil by default. If the value is nil, the accessibilityHint will not be setted.
+    ///   - hidden: the accessibility hidden. *Optional*. Nil by default. If the value is nil, the accessibilityHidden will not be setted.
+    ///   - action: the accessibility action. *Optional*. Nil by default. If the value is nil, the accessibilityAction will not be setted.
+    public init(
+        label: String? = nil,
+        value: String? = nil,
+        inputLabels: [String]? = nil,
+        hint: String? = nil,
+        hidden: Bool? = nil,
+        action: Accessibility.Action? = nil
+    ) {
+        self.label = label
+        self.value = value
+        self.inputLabels = inputLabels
+        self.hint = hint
+        self.hidden = hidden
+        self.action = action
+    }
+
+    // MARK: - Sub Struct
+
+    public struct Action {
+
+        // MARK: - Properties
+
+        internal let name: String
+        internal let handler: () -> Void
+
+        // MARK: - Initialization
+
+        /// Init the accessibility action struct.
+        /// - Parameters:
+        ///   - name: the name of the accessibility action
+        ///   - handler: the handler of the accessibility action.
+        public init(
+            name: String,
+            handler: @escaping () -> Void
+        ) {
+            self.name = name
+            self.handler = handler
+        }
+    }
+}

--- a/Sources/Core/Accessibility/ViewModifier/AccessibilityChildViewModifier.swift
+++ b/Sources/Core/Accessibility/ViewModifier/AccessibilityChildViewModifier.swift
@@ -1,0 +1,104 @@
+//
+//  AccessibilityChildViewModifier.swift
+//  SparkCommon
+//
+//  Created by robin.lemaire on 16/12/2024.
+//  Copyright © 2024 Adevinta. All rights reserved.
+//
+
+import SwiftUI
+
+private struct AccessibilityChildViewModifier: ViewModifier {
+
+    // MARK: - Properties
+
+    private let accessibility: Accessibility
+
+    // MARK: - Initialization
+
+    init(accessibility: Accessibility) {
+        self.accessibility = accessibility
+    }
+
+    // MARK: - Content
+
+    func body(content: Content) -> some View {
+        content.optionalAccessibilityLabel(self.accessibility.label)
+            .optionalAccessibilityValue(self.accessibility.value)
+            .optionalAccessibilityInputLabels(self.accessibility.inputLabels)
+            .optionalAccessibilityHint(self.accessibility.hint)
+            .optionalAccessibilityHidden(self.accessibility.hidden)
+            .optionalAccessibilityAction(self.accessibility.action)
+    }
+}
+
+// MARK: - Public Extension
+
+@_spi(SI_SPI) public extension View {
+
+    /// Add some accessibility properties from struct.
+    /// - Parameters:
+    ///   - accessibility: the accessibility properties struct.
+    func accessibility(_ accessibility: Accessibility) -> some View {
+        self.modifier(AccessibilityChildViewModifier(accessibility: accessibility))
+    }
+}
+
+// MARK: - Private Extension
+
+private extension View {
+
+    @ViewBuilder
+    func optionalAccessibilityLabel(_ label: String?) -> some View {
+        if let label {
+            self.accessibilityLabel(label)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func optionalAccessibilityValue(_ value: String?) -> some View {
+        if let value {
+            self.accessibilityValue(value)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func optionalAccessibilityInputLabels(_ inputLabels: [String]?) -> some View {
+        if let inputLabels {
+            self.accessibilityInputLabels(inputLabels)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func optionalAccessibilityHint(_ hint: String?) -> some View {
+        if let hint {
+            self.accessibilityHint(hint)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func optionalAccessibilityHidden(_ hidden: Bool?) -> some View {
+        if let hidden {
+            self.accessibilityHidden(hidden)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func optionalAccessibilityAction(_ action: Accessibility.Action?) -> some View {
+        if let action {
+            self.accessibilityAction(named: action.name, action.handler)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR is to manage all accessibility properties (except the identifier) of a SwiftUI subviews in Spark component.
So we in a component View we just need to have an accessibility variable for each subviews. 

Example: 
```swift

public struct MyView: View {

    // MARK: - Properties

    private var titleAccessibility: Accessibility = .init()

    // MARK: - View

    public var body: some View {
        VStack(alignment: .leading) {
            Text("My title")
                .accessibilityIdentifier("My Title Identifier")
                .accessibility(self.titleAccessibility)
        }
        .accessibilityElement(children: .contain)
        .accessibilityIdentifier(FormFieldAccessibilityIdentifier.formField)
    }

   // MARK: - Modifiers

    public func titleAccessibilityLabel(_ label: String) -> Self {
        var copy = self
        copy.titleAccessibility.label = label
        return copy
    }

    public func titleAccessibilityValue(_ value: String) -> Self {
        var copy = self
        copy.titleAccessibility.value = value
        return copy
    }
}
```