### PR TITLE
Add SparkFeatureToggleService to manage feature toggle

### DIFF
--- a/Sources/Core/FeatureToggles/SparkFeatureToggleService.swift
+++ b/Sources/Core/FeatureToggles/SparkFeatureToggleService.swift
@@ -1,0 +1,34 @@
+//
+//  SparkFeatureToggleService.swift
+//  SparkCommon
+//
+//  Created by robin.lemaire on 07/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+// sourcery: AutoMockable
+public protocol SparkFeatureToggleServicing {
+    var rebranding: Bool { get set }
+}
+
+public struct SparkFeatureToggleService: SparkFeatureToggleServicing {
+
+    // MARK: - Static Properties
+
+    public static var shared: any SparkFeatureToggleServicing = SparkFeatureToggleService()
+
+    // MARK: - Properties
+
+    public var rebranding: Bool = false
+
+    // MARK: - Initialization
+
+    private init() {
+    }
+
+    // MARK: - Static Func
+
+    @_spi(SI_SPI) public static func reset() {
+        self.shared = SparkFeatureToggleService()
+    }
+}

--- a/Sources/Core/FeatureToggles/SparkFeatureToggleService.swift
+++ b/Sources/Core/FeatureToggles/SparkFeatureToggleService.swift
@@ -6,19 +6,24 @@
 //  Copyright © 2026 Leboncoin. All rights reserved.
 //
 
+/// Protocol defining the interface for feature toggle service.
 // sourcery: AutoMockable
 public protocol SparkFeatureToggleServicing {
+    /// Indicates whether the rebranding feature is enabled.
     var rebranding: Bool { get set }
 }
 
+/// Service managing feature toggles for the Spark design system.
 public struct SparkFeatureToggleService: SparkFeatureToggleServicing {
 
     // MARK: - Static Properties
 
+    /// Shared instance of the feature toggle service. Can be replaced for testing purposes.
     public static var shared: any SparkFeatureToggleServicing = SparkFeatureToggleService()
 
     // MARK: - Properties
 
+    /// Indicates whether the rebranding feature is enabled. Default is `false`.
     public var rebranding: Bool = false
 
     // MARK: - Initialization
@@ -28,6 +33,8 @@ public struct SparkFeatureToggleService: SparkFeatureToggleServicing {
 
     // MARK: - Static Func
 
+    /// Resets the shared instance to its default state with all feature toggles disabled.
+    /// - Note: This method is intended for testing purposes only.
     @_spi(SI_SPI) public static func reset() {
         self.shared = SparkFeatureToggleService()
     }

--- a/Tests/UnitTests/FeatureToggles/SparkFeatureToggleServiceTests.swift
+++ b/Tests/UnitTests/FeatureToggles/SparkFeatureToggleServiceTests.swift
@@ -60,7 +60,7 @@ struct SparkFeatureToggleServiceTests {
         #expect(SparkFeatureToggleService.shared is SparkFeatureToggleServicingGeneratedMock, "shared instance should be a mock before reset")
 
         // WHEN
-        SparkFeatureToggleService.shared = SparkFeatureToggleService()
+        SparkFeatureToggleService.reset()
 
         // THEN
         #expect(SparkFeatureToggleService.shared is SparkFeatureToggleService, "shared instance should be of type SparkFeatureToggleService after reset")

--- a/Tests/UnitTests/FeatureToggles/SparkFeatureToggleServiceTests.swift
+++ b/Tests/UnitTests/FeatureToggles/SparkFeatureToggleServiceTests.swift
@@ -1,0 +1,69 @@
+//
+//  SparkFeatureToggleServiceTests.swift
+//  SparkCommonTests
+//
+//  Created on 07/05/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import Testing
+@_spi(SI_SPI) @testable import SparkCommon
+@_spi(SI_SPI) import SparkCommonTesting
+
+@Suite("SparkFeatureToggleService Tests", .serialized)
+struct SparkFeatureToggleServiceTests {
+
+    // MARK: - Tests
+
+    @Test("Shared instance should have default values")
+    func shared_instance_default_values() {
+        // GIVEN / WHEN
+        let service = SparkFeatureToggleService.shared
+
+        // THEN
+        #expect(service is SparkFeatureToggleService, "service should be an instance of SparkFeatureToggleService")
+        #expect(!service.rebranding, "rebranding should be false by default")
+    }
+
+    @Test("Rebranding setter should update the property value")
+    func rebranding_setter() {
+        // GIVEN
+        SparkFeatureToggleService.shared.rebranding = true
+
+        // WHEN
+        let result = SparkFeatureToggleService.shared.rebranding
+
+        // THEN
+        #expect(result, "rebranding getter should return the set value")
+    }
+
+    @Test("Shared instance should be replaceable")
+    func shared_instance_replaceable() {
+        // GIVEN
+        let mockService = SparkFeatureToggleServicingGeneratedMock()
+        mockService.rebranding = true
+
+        // WHEN
+        SparkFeatureToggleService.shared = mockService
+
+        // THEN
+        #expect(SparkFeatureToggleService.shared.rebranding, "shared instance should be replaceable with a mock")
+        #expect(SparkFeatureToggleService.shared is SparkFeatureToggleServicingGeneratedMock, "shared instance should be of type SparkFeatureToggleServicingGeneratedMock")
+    }
+
+    @Test("Shared instance should reset from mock to default service")
+    func shared_instance_reset_from_mock() {
+        // GIVEN
+        let mockService = SparkFeatureToggleServicingGeneratedMock()
+        mockService.rebranding = true
+        SparkFeatureToggleService.shared = mockService
+        #expect(SparkFeatureToggleService.shared is SparkFeatureToggleServicingGeneratedMock, "shared instance should be a mock before reset")
+
+        // WHEN
+        SparkFeatureToggleService.shared = SparkFeatureToggleService()
+
+        // THEN
+        #expect(SparkFeatureToggleService.shared is SparkFeatureToggleService, "shared instance should be of type SparkFeatureToggleService after reset")
+        #expect(!SparkFeatureToggleService.shared.rebranding, "rebranding should be false after reset")
+    }
+}


### PR DESCRIPTION
Refactor SparkFeatureToggleServiceProtocol to SparkFeatureToggleService with a new simplified architecture:
- Add SparkFeatureToggleServicing protocol with rebranding property
- Implement SparkFeatureToggleService as a singleton with private initializer
- Add shared instance that can be replaced for testing
- Add reset() method to restore default shared instance
- Add comprehensive unit tests using Swift Testing framework
- Tests cover default values, property getters/setters, protocol conformance, and instance replaceability