### PR TITLE
[Refactor] Simplify SwiftUI border and corner radius modifiers

### DIFF
--- a/Sources/Core/Scaled/Border/SwiftUI/ScaledBorderRadiusViewModifier.swift
+++ b/Sources/Core/Scaled/Border/SwiftUI/ScaledBorderRadiusViewModifier.swift
@@ -94,11 +94,11 @@ private struct ScaledBorderRadiusViewModifier: ViewModifier {
             )
             .overlay {
                 UnevenRoundedRectangle(
-                   topLeadingRadius: self._topLeadingRadius.value(scaled: self.isScaled),
-                   bottomLeadingRadius: self._bottomLeadingRadius.value(scaled: self.isScaled),
-                   bottomTrailingRadius: self._bottomTrailingRadius.value(scaled: self.isScaled),
-                   topTrailingRadius: self._topTrailingRadius.value(scaled: self.isScaled),
-                   isHighlighted: self.isHighlighted
+                    topLeadingRadius: self._topLeadingRadius.value(scaled: self.isScaled),
+                    bottomLeadingRadius: self._bottomLeadingRadius.value(scaled: self.isScaled),
+                    bottomTrailingRadius: self._bottomTrailingRadius.value(scaled: self.isScaled),
+                    topTrailingRadius: self._topTrailingRadius.value(scaled: self.isScaled),
+                    isHighlighted: self.isHighlighted
                 )
                 .inset(by: self.position.inset(width: self._width.value(scaled: self.isScaled)))
                 .stroke(
@@ -155,7 +155,6 @@ public extension View {
     ///         colorToken: YourThemes.shared.colors.main.main
     ///     )
     /// ```
-    @ViewBuilder
     func sparkBorder(
         width: CGFloat,
         radius: CGFloat,
@@ -165,23 +164,15 @@ public extension View {
         position: BorderPosition = .default,
         isScaled: Bool = true
     ) -> some View {
-        if width > 0 {
-            self.modifier(ScaledBorderRadiusViewModifier(
-                width: width,
-                radius: radius,
-                dash: dash,
-                isHighlighted: isHighlighted,
-                colorToken: colorToken,
-                position: position,
-                isScaled: isScaled
-            ))
-        } else {
-            self.sparkCornerRadius(
-                radius,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            )
-        }
+        self.modifier(ScaledBorderRadiusViewModifier(
+            width: width,
+            radius: radius,
+            dash: dash,
+            isHighlighted: isHighlighted,
+            colorToken: colorToken,
+            position: position,
+            isScaled: isScaled
+        ))
     }
 }
 
@@ -238,7 +229,6 @@ public extension View {
     ///         colorToken: YourThemes.shared.colors.main.main
     ///     )
     /// ```
-    @ViewBuilder
     func sparkBorder(
         width: CGFloat,
         topLeadingRadius: CGFloat,
@@ -251,29 +241,18 @@ public extension View {
         position: BorderPosition = .default,
         isScaled: Bool = true
     ) -> some View {
-        if width > 0, topLeadingRadius > 0 || topTrailingRadius > 0 || bottomTrailingRadius > 0 || bottomLeadingRadius > 0 {
-            self.modifier(ScaledBorderRadiusViewModifier(
-                width: width,
-                topLeadingRadius: topLeadingRadius,
-                topTrailingRadius: topTrailingRadius,
-                bottomTrailingRadius: bottomTrailingRadius,
-                bottomLeadingRadius: bottomLeadingRadius,
-                dash: dash,
-                isHighlighted: isHighlighted,
-                colorToken: colorToken,
-                position: position,
-                isScaled: isScaled
-            ))
-        } else {
-            self.sparkCornerRadius(
-                topLeading: topLeadingRadius,
-                topTrailing: topTrailingRadius,
-                bottomTrailing: bottomTrailingRadius,
-                bottomLeading: bottomLeadingRadius,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            )
-        }
+        self.modifier(ScaledBorderRadiusViewModifier(
+            width: width,
+            topLeadingRadius: topLeadingRadius,
+            topTrailingRadius: topTrailingRadius,
+            bottomTrailingRadius: bottomTrailingRadius,
+            bottomLeadingRadius: bottomLeadingRadius,
+            dash: dash,
+            isHighlighted: isHighlighted,
+            colorToken: colorToken,
+            position: position,
+            isScaled: isScaled
+        ))
     }
 
     /// Add a **Spark** border with corner radius to the current view.
@@ -319,7 +298,6 @@ public extension View {
     ///         colorToken: YourThemes.shared.colors.main.main
     ///     )
     /// ```
-    @ViewBuilder
     func sparkBorder(
         width: CGFloat,
         topRadius: CGFloat,
@@ -330,27 +308,18 @@ public extension View {
         position: BorderPosition = .default,
         isScaled: Bool = true
     ) -> some View {
-        if width > 0, topRadius > 0 || bottomRadius > 0 {
-            self.modifier(ScaledBorderRadiusViewModifier(
-                width: width,
-                topLeadingRadius: topRadius,
-                topTrailingRadius: topRadius,
-                bottomTrailingRadius: bottomRadius,
-                bottomLeadingRadius: bottomRadius,
-                dash: dash,
-                isHighlighted: isHighlighted,
-                colorToken: colorToken,
-                position: position,
-                isScaled: isScaled
-            ))
-        } else {
-            self.sparkCornerRadius(
-                top: topRadius,
-                bottom: bottomRadius,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            )
-        }
+        self.modifier(ScaledBorderRadiusViewModifier(
+            width: width,
+            topLeadingRadius: topRadius,
+            topTrailingRadius: topRadius,
+            bottomTrailingRadius: bottomRadius,
+            bottomLeadingRadius: bottomRadius,
+            dash: dash,
+            isHighlighted: isHighlighted,
+            colorToken: colorToken,
+            position: position,
+            isScaled: isScaled
+        ))
     }
 
     /// Add a **Spark** border with corner radius to the current view.
@@ -396,7 +365,6 @@ public extension View {
     ///         colorToken: YourThemes.shared.colors.main.main
     ///     )
     /// ```
-    @ViewBuilder
     func sparkBorder(
         width: CGFloat,
         leadingRadius: CGFloat,
@@ -407,27 +375,18 @@ public extension View {
         position: BorderPosition = .default,
         isScaled: Bool = true
     ) -> some View {
-        if width > 0, leadingRadius > 0 || trailingRadius > 0 {
-            self.modifier(ScaledBorderRadiusViewModifier(
-                width: width,
-                topLeadingRadius: leadingRadius,
-                topTrailingRadius: trailingRadius,
-                bottomTrailingRadius: trailingRadius,
-                bottomLeadingRadius: leadingRadius,
-                dash: dash,
-                isHighlighted: isHighlighted,
-                colorToken: colorToken,
-                position: position,
-                isScaled: isScaled
-            ))
-        } else {
-            self.sparkCornerRadius(
-                leading: leadingRadius,
-                trailing: trailingRadius,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            )
-        }
+        self.modifier(ScaledBorderRadiusViewModifier(
+            width: width,
+            topLeadingRadius: leadingRadius,
+            topTrailingRadius: trailingRadius,
+            bottomTrailingRadius: trailingRadius,
+            bottomLeadingRadius: leadingRadius,
+            dash: dash,
+            isHighlighted: isHighlighted,
+            colorToken: colorToken,
+            position: position,
+            isScaled: isScaled
+        ))
     }
 }
 

--- a/Sources/Core/Scaled/Border/SwiftUI/ScaledBorderViewModifier.swift
+++ b/Sources/Core/Scaled/Border/SwiftUI/ScaledBorderViewModifier.swift
@@ -93,7 +93,6 @@ public extension View {
     ///         colorToken: YourThemes.shared.colors.main.main
     ///     )
     /// ```
-    @ViewBuilder
     func sparkBorder(
         width: CGFloat,
         dash: CGFloat? = nil,

--- a/Sources/Core/Scaled/Border/SwiftUI/ScaledCornerRadiusViewModifier.swift
+++ b/Sources/Core/Scaled/Border/SwiftUI/ScaledCornerRadiusViewModifier.swift
@@ -60,13 +60,13 @@ private struct ScaledCornerRadiusViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-             .clipShape(UnevenRoundedRectangle(
+            .clipShape(UnevenRoundedRectangle(
                 topLeadingRadius: self._topLeadingRadius.value(scaled: self.isScaled),
                 bottomLeadingRadius: self._bottomLeadingRadius.value(scaled: self.isScaled),
                 bottomTrailingRadius: self._bottomTrailingRadius.value(scaled: self.isScaled),
                 topTrailingRadius: self._topTrailingRadius.value(scaled: self.isScaled),
                 isHighlighted: self.isHighlighted
-             ))
+            ))
     }
 }
 
@@ -99,21 +99,16 @@ public extension View {
     ///     .frame(width: 80, height: 30)
     ///     .sparkCornerRadius(12, isScaled: false)
     /// ```
-    @ViewBuilder
     func sparkCornerRadius(
         _ radius: CGFloat,
         isHighlighted: Bool = false,
         isScaled: Bool = true
     ) -> some View {
-        if radius > 0 {
-            self.modifier(ScaledCornerRadiusViewModifier(
-                radius: radius,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            ))
-        } else {
-            self
-        }
+        self.modifier(ScaledCornerRadiusViewModifier(
+            radius: radius,
+            isHighlighted: isHighlighted,
+            isScaled: isScaled
+        ))
     }
 }
 
@@ -161,7 +156,6 @@ public extension View {
     ///         isScaled: false
     ///     )
     /// ```
-    @ViewBuilder
     func sparkCornerRadius(
         topLeading: CGFloat,
         topTrailing: CGFloat,
@@ -170,18 +164,14 @@ public extension View {
         isHighlighted: Bool = false,
         isScaled: Bool = true
     ) -> some View {
-        if topLeading > 0 || topTrailing > 0 || bottomTrailing > 0 || bottomLeading > 0 {
-            self.modifier(ScaledCornerRadiusViewModifier(
-                topLeadingRadius: topLeading,
-                topTrailingRadius: topTrailing,
-                bottomTrailingRadius: bottomTrailing,
-                bottomLeadingRadius: bottomLeading,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            ))
-        } else {
-            self
-        }
+        self.modifier(ScaledCornerRadiusViewModifier(
+            topLeadingRadius: topLeading,
+            topTrailingRadius: topTrailing,
+            bottomTrailingRadius: bottomTrailing,
+            bottomLeadingRadius: bottomLeading,
+            isHighlighted: isHighlighted,
+            isScaled: isScaled
+        ))
     }
 
     /// Add a **Spark** uneven corner radius to the current view.
@@ -218,25 +208,20 @@ public extension View {
     ///         isScaled: false
     ///     )
     /// ```
-    @ViewBuilder
     func sparkCornerRadius(
         top: CGFloat,
         bottom: CGFloat,
         isHighlighted: Bool = false,
         isScaled: Bool = true
     ) -> some View {
-        if top > 0 || bottom > 0 {
-            self.modifier(ScaledCornerRadiusViewModifier(
-                topLeadingRadius: top,
-                topTrailingRadius: top,
-                bottomTrailingRadius: bottom,
-                bottomLeadingRadius: bottom,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            ))
-        } else {
-            self
-        }
+        self.modifier(ScaledCornerRadiusViewModifier(
+            topLeadingRadius: top,
+            topTrailingRadius: top,
+            bottomTrailingRadius: bottom,
+            bottomLeadingRadius: bottom,
+            isHighlighted: isHighlighted,
+            isScaled: isScaled
+        ))
     }
 
     /// Add a **Spark** uneven corner radius to the current view.
@@ -273,24 +258,19 @@ public extension View {
     ///         isScaled: false
     ///     )
     /// ```
-    @ViewBuilder
     func sparkCornerRadius(
         leading: CGFloat,
         trailing: CGFloat,
         isHighlighted: Bool = false,
         isScaled: Bool = true
     ) -> some View {
-        if leading > 0 || trailing > 0 {
-            self.modifier(ScaledCornerRadiusViewModifier(
-                topLeadingRadius: leading,
-                topTrailingRadius: trailing,
-                bottomTrailingRadius: trailing,
-                bottomLeadingRadius: leading,
-                isHighlighted: isHighlighted,
-                isScaled: isScaled
-            ))
-        } else {
-            self
-        }
+        self.modifier(ScaledCornerRadiusViewModifier(
+            topLeadingRadius: leading,
+            topTrailingRadius: trailing,
+            bottomTrailingRadius: trailing,
+            bottomLeadingRadius: leading,
+            isHighlighted: isHighlighted,
+            isScaled: isScaled
+        ))
     }
 }


### PR DESCRIPTION
Remove conditional @ViewBuilder logic from sparkBorder and sparkCornerRadius view modifiers. The modifiers now always apply regardless of parameter values, simplifying the implementation and ensuring consistent behavior. This includes proper indentation fixes in UnevenRoundedRectangle usage.